### PR TITLE
Add `anything` subject option to grimshot

### DIFF
--- a/grimshot
+++ b/grimshot
@@ -56,7 +56,7 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimshot [--notify] [--cursor] [--wait N] (copy|save) [active|screen|output|area|window] [FILE|-]"
+  echo "  grimshot [--notify] [--cursor] [--wait N] (copy|save) [active|screen|output|area|window|anything] [FILE|-]"
   echo "  grimshot check"
   echo "  grimshot usage"
   echo ""
@@ -72,6 +72,7 @@ if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" 
   echo "  output: Currently active output."
   echo "  area: Manually select a region."
   echo "  window: Manually select a window."
+  echo "  anything: Manually select an area, window, or output."
   exit
 fi
 
@@ -159,6 +160,13 @@ elif [ "$SUBJECT" = "window" ] ; then
    exit 1
   fi
   WHAT="Window"
+elif [ "$SUBJECT" = "anything" ] ; then
+  GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp -o)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+    exit
+  fi
+  WHAT="Selection"
 else
   die "Unknown subject to take a screen shot from" "$SUBJECT"
 fi

--- a/grimshot.1
+++ b/grimshot.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "grimshot" "1" "2022-03-31"
+.TH "grimshot" "1" "2023-08-24"
 .P
 .SH NAME
 .P
@@ -40,7 +40,7 @@ order to know when the screenshot has been taken.\&
 .RE
 \fBsave\fR
 .RS 4
-Save the screenshot into a regular file.\& Grimshot will write images
+Save the screenshot into a regular file.\& Grimshot will write image
 files to \fBXDG_SCREENSHOTS_DIR\fR if this is set (or defined
 in \fBuser-dirs.\&dir\fR), or otherwise fall back to \fBXDG_PICTURES_DIR\fR.\&
 Set FILE to '\&-'\& to pipe the output to STDOUT.\&
@@ -104,6 +104,13 @@ captures it.\&
 \fIoutput\fR
 .RS 4
 Captures the currently active output.\&
+.P
+.RE
+\fIanything\fR
+.RS 4
+Allows manually selecting a single window (by clicking on it), an output (by
+clicking outside of all windows, e.\&g.\& on the status bar), or an area (by
+using click and drag).\&
 .P
 .RE
 .SH OUTPUT

--- a/grimshot.1.scd
+++ b/grimshot.1.scd
@@ -75,6 +75,11 @@ _window_
 _output_
 	Captures the currently active output.
 
+_anything_
+	Allows manually selecting a single window (by clicking on it), an output (by
+	clicking outside of all windows, e.g. on the status bar), or an area (by
+	using click and drag).
+
 # OUTPUT
 
 Grimshot will print the filename of the captured screenshot to stdout if called


### PR DESCRIPTION
This enables selecting a window, output, or area within one invocation, removing the need for multiple keybindings.
- Drag for an area (note that this already works in the `window` case)
- Click on a window to select it
- Click outside of all windows (e.g. in gaps or on the waybar) to
select the entire output

Ideally this needs some testing with multiple monitors, which I don't have.