### PR TITLE
Add `savecopy` command to grimshot

### DIFF
--- a/grimshot
+++ b/grimshot
@@ -54,7 +54,7 @@ ACTION=${1:-usage}
 SUBJECT=${2:-screen}
 FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
-if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
+if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "savecopy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
   echo "  grimshot [--notify] [--cursor] [--wait N] (copy|save) [active|screen|output|area|window|anything] [FILE|-]"
   echo "  grimshot check"
@@ -63,6 +63,7 @@ if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" 
   echo "Commands:"
   echo "  copy: Copy the screenshot data into the clipboard."
   echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
+  echo "  savecopy: Save the screenshot to a regular file and copy the data into the clipboard."
   echo "  check: Verify if required tools are installed and exit."
   echo "  usage: Show this message and exit."
   echo ""
@@ -184,6 +185,10 @@ else
     MESSAGE=$(basename "$FILE")
     notifyOk "$MESSAGE" "$TITLE"
     echo "$FILE"
+    if [ "$ACTION" = "savecopy" ]; then
+      wl-copy --type image/png < "$FILE" || die "Clipboard error"
+      notifyOk "$WHAT copied to buffer"
+    fi
   else
     notifyError "Error taking screenshot with grim"
   fi

--- a/grimshot.1
+++ b/grimshot.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "grimshot" "1" "2023-08-24"
+.TH "grimshot" "1" "2024-01-01"
 .P
 .SH NAME
 .P
@@ -49,6 +49,12 @@ Set FILE to '\&-'\& to pipe the output to STDOUT.\&
 \fBcopy\fR
 .RS 4
 Copy the screenshot data (as image/png) into the clipboard.\&
+.P
+.RE
+\fB\fRsavecopy\fB\fR
+.RS 4
+Save the screenshot into a regular file (see \fIsave\fR documentation) and
+copy the screenshot data into the clipboard (see \fIcopy\fR documentation).\&
 .P
 .RE
 .SH DESCRIPTION
@@ -116,7 +122,7 @@ using click and drag).\&
 .SH OUTPUT
 .P
 Grimshot will print the filename of the captured screenshot to stdout if called
-with the \fIsave\fR subcommand.\&
+with the \fIsave\fR or \fIsavecopy\fR subcommands.\&
 .P
 .SH SEE ALSO
 .P

--- a/grimshot.1.scd
+++ b/grimshot.1.scd
@@ -32,6 +32,10 @@ grimshot - a helper for screenshots within sway
 *copy*
 	Copy the screenshot data (as image/png) into the clipboard.
 
+**savecopy**
+	Save the screenshot into a regular file (see _save_ documentation) and
+	copy the screenshot data into the clipboard (see _copy_ documentation).
+
 # DESCRIPTION
 
 Grimshot is an easy-to-use screenshot utility for sway. It provides a
@@ -83,7 +87,7 @@ _anything_
 # OUTPUT
 
 Grimshot will print the filename of the captured screenshot to stdout if called
-with the _save_ subcommand.
+with the _save_ or _savecopy_ subcommands.
 
 # SEE ALSO
 


### PR DESCRIPTION
This builds on the work done in swaywm/sway#5919 and swaywm/sway#7328 to add a grimshot command that both saves the screenshot to a file and copies the screenshot to the clipboard.