### PR TITLE
Fix wait check

### DIFF
--- a/grimshot
+++ b/grimshot
@@ -126,6 +126,10 @@ takeScreenshot() {
   fi
 }
 
+if [ "$WAIT" != "no" ]; then
+  sleep "$WAIT"
+fi
+
 if [ "$ACTION" = "check" ] ; then
   echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
   check grim
@@ -170,10 +174,6 @@ elif [ "$SUBJECT" = "anything" ] ; then
   WHAT="Selection"
 else
   die "Unknown subject to take a screen shot from" "$SUBJECT"
-fi
-
-if [ "$WAIT" != "no" ]; then
-  sleep "$WAIT"
 fi
 
 if [ "$ACTION" = "copy" ] ; then


### PR DESCRIPTION
When utilizing the `--wait` flag, the condition gets fulfilled AFTER taking the screenshot.
Moving the conditional up fixed this issue.

Tested with this command:

```
grimshot --notify --wait 3 savecopy anything "$HOME/Pictures/$(date +"%Y-%m-%d_%H-%M-%S").png"
```