### PR TITLE
feature: added active vs inactive

### DIFF
--- a/inactive-windows-transparency.py
+++ b/inactive-windows-transparency.py
@@ -29,7 +29,10 @@ def on_window_focus(args, ipc, event):
         focused.command("opacity " + args.focused)
         if workspace == prev_workspace:
             prev_focused.command("opacity " + args.opacity)
-        prev_focused = focused prev_workspace = workspace
+        prev_focused = focused
+        prev_workspace = workspace
+
+
 def remove_opacity(ipc, focused_opacity):
     for workspace in ipc.get_tree().workspaces():
         for w in workspace:


### PR DESCRIPTION
## Overview

I had previously used i3 + picom to have window opacity in a way that the active window has some level of transparency, and inactive windows were slightly more transparent. 

This modification adds a `-f` arg to `inactive-windows-transparency.py` that allows a specific opacity for the active window in relation to others (as opposed to the static 1 opacity). 

I have kept the previous arg as `--opacity -o` for compatibility purposes; however, I would have preferred to have it called `--inactive -i` to represent "inactive windows' opacity" compared to "focused window opacity".