### PR TITLE
Improve the robustness of inactive-windows-transparency

### DIFF
--- a/inactive-windows-transparency.py
+++ b/inactive-windows-transparency.py
@@ -33,7 +33,7 @@ def on_window(args, ipc, event):
         window = tree.find_by_id(window_id)
         if window is None:
             to_remove.add(window_id)
-        elif window.workspace() == focused_workspace:
+        elif args.global_focus or window.workspace() == focused_workspace:
             window.command("opacity " + args.opacity)
             to_remove.add(window_id)
 
@@ -64,6 +64,12 @@ if __name__ == "__main__":
         type=str,
         default="1.0",
         help="set focused opacity value in range 0...1",
+    )
+    parser.add_argument(
+        "--global-focus",
+        "-g",
+        action="store_true",
+        help="only have one opaque window across all workspaces",
     )
     args = parser.parse_args()
 

--- a/inactive-windows-transparency.py
+++ b/inactive-windows-transparency.py
@@ -13,15 +13,14 @@ from functools import partial
 import i3ipc
 
 
-def on_window_focus(args, ipc, event):
+def on_window(args, ipc, event):
     global focused_set
 
     # To get the workspace for a container, we need to have received its
     # parents, so fetch the whole tree
     tree = ipc.get_tree()
 
-    focused_id = event.container.id
-    focused = tree.find_by_id(focused_id)
+    focused = tree.find_focused()
     focused_workspace = focused.workspace()
 
     focused.command("opacity " + args.focused)
@@ -79,5 +78,5 @@ if __name__ == "__main__":
             window.command("opacity " + args.opacity)
     for sig in [signal.SIGINT, signal.SIGTERM]:
         signal.signal(sig, lambda signal, frame: remove_opacity(ipc, args.focused))
-    ipc.on("window::focus", partial(on_window_focus, args))
+    ipc.on("window", partial(on_window, args))
     ipc.main()


### PR DESCRIPTION
This PR reworks inactive-windows-transparency to store a set of all focused windows, rather than just the previous focused window. This makes it behave correctly with regards to more window operations. It also adds an option to only have one opaque window across all workspaces.

I think this closes #12.