### PR TITLE
Fix grimshot trying to send notification even when disabled

### DIFF
--- a/grimshot/grimshot
+++ b/grimshot/grimshot
@@ -123,7 +123,9 @@ notifyOk() {
   notify_disabled='[ "$NOTIFY" = "no" ]'
   action_involves_saving='[ "$ACTION" = "save" ] || [ "$ACTION" = "savecopy" ]'
 
-  when "$notify_disabled" "return"
+  if eval $notify_disabled; then
+	  return
+  fi
 
   TITLE=${2:-"Screenshot"}
   MESSAGE=${1:-"OK"}


### PR DESCRIPTION
Grimshot was trying to send notification by default, even when not enabled.

The bug was that the check NOTIFY=no was done in the when() function. The "enter" was thus exiting the when() function instead of the notifyOk().

Fix was to replace the when() call by a simple if/then/fi