### PR TITLE
fix(float-window-manager): sway version compare

### DIFF
--- a/float-window-manager/float-window-managerd.sh
+++ b/float-window-manager/float-window-managerd.sh
@@ -41,10 +41,12 @@ else
 fi
 
 
+min_version="1.6"
 version=$(swaymsg -t get_version | jq -r '.human_readable')
-if [[ "$version" < "1.6" ]]; then
+if [ "$(echo -e "$version\n$min_version" | sort -V | head -n 1)" != "$min_version" ]; then
+  # True if $version is less than $min_version
 	echo This version of Sway is earlier than supports moving windows with percentages.
-	echo Version is \'"$version"\'. Version needed: \'1.6\'.
+	echo Version is \'"$version"\'. Version needed: \'"$min_version"\'.
 	exit 1
 fi
 


### PR DESCRIPTION
String compare will cause issues like "1.10.1 is smaller than 1.6".

```
This version of Sway is earlier than supports moving windows with percentages.
Version is '1.10.1'. Version needed: '1.6'.
```

We can use `sort -V` instead.