### PR TITLE
inactive-windows-transparency: Fix crashes when there is no focused window

### DIFF
--- a/inactive-windows-transparency.py
+++ b/inactive-windows-transparency.py
@@ -21,19 +21,20 @@ def on_window(args, ipc, event):
     tree = ipc.get_tree()
 
     focused = tree.find_focused()
-    focused_workspace = focused.workspace()
+    if focused is not None:
+        focused_workspace = focused.workspace()
 
-    focused.command("opacity " + args.focused)
-    focused_set.add(focused.id)
+        focused.command("opacity " + args.focused)
+        focused_set.add(focused.id)
 
     to_remove = set()
     for window_id in focused_set:
-        if window_id == focused.id:
+        if focused is not None and window_id == focused.id:
             continue
         window = tree.find_by_id(window_id)
         if window is None:
             to_remove.add(window_id)
-        elif args.global_focus or window.workspace() == focused_workspace:
+        elif args.global_focus or (focused is not None and window.workspace() == focused_workspace):
             window.command("opacity " + args.opacity)
             to_remove.add(window_id)
 


### PR DESCRIPTION
I don't know exactly when this happens (maybe on lock screen?), but sometimes sway does not report any focused window, and this results in a crash in inactive-windows-transparency.py.

```
'NoneType' object has no attribute 'workspace'
Traceback (most recent call last):
  File "/usr/share/sway-contrib/inactive-windows-transparency.py", line 88, in <module>
    ipc.main()
    ~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 514, in main
    raise loop_exception
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 497, in main
    while not self._event_socket_poll():
              ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 477, in _event_socket_poll
    raise e
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 474, in _event_socket_poll
    self._pubsub.emit(event_name, event)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/i3ipc/_private/pubsub.py", line 28, in emit
    s['handler'](self.conn, data)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/share/sway-contrib/inactive-windows-transparency.py", line 24, in on_window
    focused_workspace = focused.workspace()
                        ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'workspace'
```