### PR TITLE
swaystack.py: A workspace hoarding utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | inactive-windows-transparency.py | Makes inactive windows transparent |
 | layout-per-window.py | A script keeps track of the active layout for each window |
 | switch-top-level.py | A script allows you to define two new bindings |
+| swaystack.py | A script for hoarding workspaces in stacks |
 
 
 ## Contributing

--- a/swaystack.py
+++ b/swaystack.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
 
+# This script requires i3ipc-python package (install it from a system package
+# manager or pip).
+# The script "stacks" numbered workspaces 1-10 onto 11-20, 21-30, etc
+# Useful for hoarding workspaces, or if you're working on a project and need
+# to focus on something else, but don't wanna close your workspaces
+# This script doesn't proivde a way to view workspaces in the stack, nor does it
+# expect you to provide one in your sway config. The stack is for storage; pop
+# workspaces onto the "home row" (1-10) to view them.
+
+# Example sway config:
+#
+# set $mod Mod4
+# set $alt Mod1
+# bindsym $mod+$alt+s exec /path/to/swaystack.py --up
+# bindsym $mod+$alt+d exec /path/to/swaystack.py --down
+# bindsym $mod+$alt+r exec /path/to/swaystack.py --rot-down
+# bindsym $mod+$alt+e exec /path/to/swaystack.py --rot-up
+
 import argparse
 import i3ipc
-
-# minimal code reuse because of weird edge cases in each
-# better just to have separate functions imo
-# could improve code reuse, but the easy way adds flickering and the hard way
-# is probably worse
 
 def shift_up(workspace):
     workspace_num = workspace.num
@@ -117,27 +130,29 @@ def rotate_up(workspace):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Workspace stacking! For hoarding workspaces!"
+        description="Workspace stacking, for hoarding workspaces. Requires "
+        "numerical workspaces 1-10."
     )
-    parser.add_argument(
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument(
         "--up",
         action='store_true',
-        help="push stack",
+        help="Push non-empty focused workspace onto stack (default)",
     )
-    parser.add_argument(
+    action.add_argument(
         "--down",
         action='store_true',
-        help="pop stack",
+        help="Pop top of stack onto empty focused workspace",
     )
-    parser.add_argument(
+    action.add_argument(
         "--rot-down",
         action='store_true',
-        help="pop stack",
+        help="Rotate down along the focused workspace stack",
     )
-    parser.add_argument(
+    action.add_argument(
         "--rot-up",
         action='store_true',
-        help="pop stack",
+        help="Rotate up along the focused workspace stack",
     )
     args = parser.parse_args()
 
@@ -152,4 +167,3 @@ if __name__ == "__main__":
         rotate_up(focused)
     else:
         shift_up(focused)
-

--- a/swaystack.py
+++ b/swaystack.py
@@ -19,7 +19,9 @@
 # bindsym $mod+$alt+e exec /path/to/swaystack.py --rot-up
 
 import argparse
+
 import i3ipc
+
 
 def shift_up(workspace):
     workspace_num = workspace.num
@@ -130,22 +132,22 @@ if __name__ == "__main__":
     action = parser.add_mutually_exclusive_group()
     action.add_argument(
         "--up",
-        action='store_true',
+        action="store_true",
         help="Push non-empty focused workspace onto stack (default)",
     )
     action.add_argument(
         "--down",
-        action='store_true',
+        action="store_true",
         help="Pop top of stack onto empty focused workspace",
     )
     action.add_argument(
         "--rot-down",
-        action='store_true',
+        action="store_true",
         help="Rotate down along the focused workspace stack",
     )
     action.add_argument(
         "--rot-up",
-        action='store_true',
+        action="store_true",
         help="Rotate up along the focused workspace stack",
     )
     args = parser.parse_args()

--- a/swaystack.py
+++ b/swaystack.py
@@ -33,17 +33,13 @@ def shift_up(workspace):
              if w.num % 10 == stack_num and w.num != 0)
     sorted_stack = sorted(stack, key=lambda w: w.num, reverse=True)
 
-    if not workspace.leaves():
-        # if empty, grab from top instead
-        top_num = sorted_stack[0].num
-        ipc.command(f"workspace {top_num}")
-        ipc.command(f"rename workspace {top_num} to {workspace_num}")
-    else:
+    if workspace.leaves():
         # if not empty, push up into stack
         for ws in sorted_stack:
             num = ws.num
             ipc.command(f"rename workspace {num} to {num+10}")
         ipc.command(f"workspace {workspace_num}")
+    # else, do nothing
 
 
 def shift_down(workspace):
@@ -58,18 +54,14 @@ def shift_down(workspace):
              if w.num % 10 == stack_num and w.num > 10)
     sorted_stack = sorted(stack, key=lambda w: w.num)
 
-    if workspace.leaves():
-        # if workspace not empty, place on the opposite end of the stack
-        top_num = sorted_stack[-1].num
-        ipc.command(f"rename workspace {workspace_num} to {top_num+10}")
-        ipc.command(f"workspace {workspace_num}")
-    else:
+    if not workspace.leaves():
         bottom_num = sorted_stack[0].num
         ipc.command(f"workspace {bottom_num}")
         # if empty, pop down from the stack
         for ws in sorted_stack:
             num = ws.num
             ipc.command(f"rename workspace {num} to {num-10}")
+    # else, do nothing
 
 
 def rotate_down(workspace):
@@ -81,6 +73,7 @@ def rotate_down(workspace):
 
     stack_num = workspace_num % 10
 
+    # TODO: cleanup repeat code
     if workspace.leaves():
         # if workspace not empty, place on opposite end of stack
         stack = (w for w in ipc.get_workspaces() 
@@ -110,6 +103,7 @@ def rotate_up(workspace):
 
     stack_num = workspace_num % 10
 
+    # TODO: cleanup repeat code
     if workspace.leaves():
         stack = (w for w in ipc.get_workspaces() 
                  if w.num % 10 == stack_num and w.num != 0)

--- a/swaystack.py
+++ b/swaystack.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import argparse
+import i3ipc
+
+# minimal code reuse because of weird edge cases in each
+# better just to have separate functions imo
+# could improve code reuse, but the easy way adds flickering and the hard way
+# is probably worse
+
+def shift_up(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    stack_num = workspace_num % 10
+    stack = (w for w in ipc.get_workspaces() 
+             if w.num % 10 == stack_num and w.num != 0)
+    sorted_stack = sorted(stack, key=lambda w: w.num, reverse=True)
+
+    if not workspace.leaves():
+        # if empty, grab from top instead
+        top_num = sorted_stack[0].num
+        ipc.command(f"workspace {top_num}")
+        ipc.command(f"rename workspace {top_num} to {workspace_num}")
+    else:
+        # if not empty, push up into stack
+        for ws in sorted_stack:
+            num = ws.num
+            ipc.command(f"rename workspace {num} to {num+10}")
+        ipc.command(f"workspace {workspace_num}")
+
+
+def shift_down(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    stack_num = workspace_num % 10
+    stack = (w for w in ipc.get_workspaces() 
+             if w.num % 10 == stack_num and w.num > 10)
+    sorted_stack = sorted(stack, key=lambda w: w.num)
+
+    if workspace.leaves():
+        # if workspace not empty, place on the opposite end of the stack
+        top_num = sorted_stack[-1].num
+        ipc.command(f"rename workspace {workspace_num} to {top_num+10}")
+        ipc.command(f"workspace {workspace_num}")
+    else:
+        bottom_num = sorted_stack[0].num
+        ipc.command(f"workspace {bottom_num}")
+        # if empty, pop down from the stack
+        for ws in sorted_stack:
+            num = ws.num
+            ipc.command(f"rename workspace {num} to {num-10}")
+
+
+def rotate_down(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    stack_num = workspace_num % 10
+
+    if workspace.leaves():
+        # if workspace not empty, place on opposite end of stack
+        stack = (w for w in ipc.get_workspaces() 
+                 if w.num % 10 == stack_num and w.num != 0)
+        top_stack = max(stack, key=lambda w: w.num)
+        top_num = top_stack.num
+
+        ipc.command(f"rename workspace {workspace_num} to {top_num+10}")
+
+    stack = (w for w in ipc.get_workspaces() 
+             if w.num % 10 == stack_num and w.num > 10)
+    sorted_stack = sorted(stack, key=lambda w: w.num)
+
+    bottom_num = sorted_stack[0].num
+    ipc.command(f"workspace {bottom_num}")
+    for ws in sorted_stack:
+        num = ws.num
+        ipc.command(f"rename workspace {num} to {num-10}")
+
+
+def rotate_up(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    stack_num = workspace_num % 10
+
+    if workspace.leaves():
+        stack = (w for w in ipc.get_workspaces() 
+                 if w.num % 10 == stack_num and w.num != 0)
+        sorted_stack = sorted(stack, key=lambda w: w.num, reverse=True)
+
+        for ws in sorted_stack:
+            num = ws.num
+            ipc.command(f"rename workspace {num} to {num+10}")
+
+    stack = (w for w in ipc.get_workspaces() 
+             if w.num % 10 == stack_num and w.num > 10)
+    top_stack = max(stack, key=lambda w: w.num)
+    top_num = top_stack.num
+
+    ipc.command(f"workspace {top_num}")
+    ipc.command(f"rename workspace {top_num} to {workspace_num}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Workspace stacking! For hoarding workspaces!"
+    )
+    parser.add_argument(
+        "--up",
+        action='store_true',
+        help="push stack",
+    )
+    parser.add_argument(
+        "--down",
+        action='store_true',
+        help="pop stack",
+    )
+    parser.add_argument(
+        "--rot-down",
+        action='store_true',
+        help="pop stack",
+    )
+    parser.add_argument(
+        "--rot-up",
+        action='store_true',
+        help="pop stack",
+    )
+    args = parser.parse_args()
+
+    ipc = i3ipc.Connection()
+    focused = ipc.get_tree().find_focused().workspace()
+
+    if args.down:
+        shift_down(focused)
+    elif args.rot_down:
+        rotate_down(focused)
+    elif args.rot_up:
+        rotate_up(focused)
+    else:
+        shift_up(focused)
+


### PR DESCRIPTION
I created a script for what I call "stacking" workspaces. Basically, it renames workspace 'n' to workspace 'n+10' (pushing), freeing up the current workspace and hiding the previous one. When workspace 'n+10' already exists, it is renamed to 'n+10+10', and so on. To get a workspace back, it renames workspace 'n+10' to 'n' (popping), assuming 'n' is empty. I also provide options for rotating through the stack to quickly find a desired workspace.

This is very useful for me when I'm working on a big project spread across all my workspaces, and need to switch gears to something else. Rather than trying to work around my open windows, or closing all of them just to have to re-open them later, I push them into the stack and have a completely free "home row" (1-10).

This only works for workspaces 1-10. I don't see how it would work otherwise, especially considering longer names will create a mess in the top left workspace enumerator.

Right now you can only do this on one "stack" at a time. It might be useful to add an option to act on more than one workspace, to quickly get an entire project out of the way.

Right now I don't have any proper error handling. Assuming everything is working properly, I think it's best to just do nothing when trying to do an invalid operation. Probably add this later.

If you think this is a good fit for this repo, I'd be happy to maintain it. Otherwise, no hard feelings ;)