### PR TITLE
Cleanup swaystack to make stack analogy consistent

### DIFF
--- a/swaystack.py
+++ b/swaystack.py
@@ -32,11 +32,6 @@ def get_stack_top(stack_num):
 
 def workspace_push(workspace):
     workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
     top_num = get_stack_top(workspace_num)
 
     # if not empty, push onto stack
@@ -47,11 +42,6 @@ def workspace_push(workspace):
 
 def workspace_pop(workspace):
     workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
     top_num = get_stack_top(workspace_num)
 
     # if empty, pop from stack
@@ -62,16 +52,11 @@ def workspace_pop(workspace):
 
 def workspace_pop_rotate(workspace):
     workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
     top_num = get_stack_top(workspace_num)
 
     # if workspace not empty, rotate stack before pop
     if workspace.leaves():
-        for n in range(top_num, 0, -10):
+        for n in range(top_num, workspace_num-1, -10):
             ipc.command(f"rename workspace {n} to {n+10}")
 
         top_num += 10
@@ -83,11 +68,6 @@ def workspace_pop_rotate(workspace):
 
 def workspace_push_rotate(workspace):
     workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
     top_num = get_stack_top(workspace_num)
 
     # if workspace not empty, push before rotate
@@ -97,7 +77,7 @@ def workspace_push_rotate(workspace):
 
     # rotate
     ipc.command(f"workspace {workspace_num+10}")
-    for n in range(workspace_num+10, top_num+10, 10):
+    for n in range(workspace_num+10, top_num+1, 10):
         ipc.command(f"rename workspace {n} to {n-10}")
 
 
@@ -131,6 +111,10 @@ if __name__ == "__main__":
 
     ipc = i3ipc.Connection()
     focused = ipc.get_tree().find_focused().workspace()
+
+    # only call from "home row"
+    if not (focused.num >= 1 and focused.num <= 10):
+        exit(1)
 
     if args.pop:
         workspace_pop(focused)

--- a/swaystack.py
+++ b/swaystack.py
@@ -2,9 +2,10 @@
 
 # This script requires i3ipc-python package (install it from a system package
 # manager or pip).
-# The script "stacks" numbered workspaces 1-10 onto 11-20, 21-30, etc
-# Useful for hoarding workspaces, or if you're working on a project and need
-# to focus on something else, but don't wanna close your workspaces
+# The script "stacks" numbered workspaces 1-10 onto 11-20, 21-30, etc, where
+# each workspace number 1-10 has it's own stack
+# Useful to declutter your workspaces if you need to switch focus to another
+# task
 # This script doesn't proivde a way to view workspaces in the stack, nor does it
 # expect you to provide one in your sway config. The stack is for storage; pop
 # workspaces onto the "home row" (1-10) to view them.
@@ -13,115 +14,91 @@
 #
 # set $mod Mod4
 # set $alt Mod1
-# bindsym $mod+$alt+s exec /path/to/swaystack.py --up
-# bindsym $mod+$alt+d exec /path/to/swaystack.py --down
-# bindsym $mod+$alt+r exec /path/to/swaystack.py --rot-down
-# bindsym $mod+$alt+e exec /path/to/swaystack.py --rot-up
+# bindsym $mod+$alt+s exec /path/to/swaystack.py --push
+# bindsym $mod+$alt+d exec /path/to/swaystack.py --pop
+# bindsym $mod+$alt+r exec /path/to/swaystack.py --pop-rotate
+# bindsym $mod+$alt+e exec /path/to/swaystack.py --push-rotate
 
 import argparse
 
 import i3ipc
 
 
-def shift_up(workspace):
+def get_stack_top(stack_num):
+    num = stack_num % 10
+    return max(w.num for w in ipc.get_workspaces()
+               if w.num % 10 == num and w.num != 0)
+
+
+def workspace_push(workspace):
     workspace_num = workspace.num
 
     # only call from "home row"
     if not (workspace_num >= 1 and workspace_num <= 10):
         return
 
-    stack_num = workspace_num % 10
-    stack = (w for w in ipc.get_workspaces() 
-             if w.num % 10 == stack_num and w.num != 0)
-    sorted_stack = sorted(stack, key=lambda w: w.num, reverse=True)
+    top_num = get_stack_top(workspace_num)
 
+    # if not empty, push onto stack
     if workspace.leaves():
-        # if not empty, push up into stack
-        for ws in sorted_stack:
-            num = ws.num
-            ipc.command(f"rename workspace {num} to {num+10}")
-        ipc.command(f"workspace {workspace_num}")
-    # else, do nothing
-
-
-def shift_down(workspace):
-    workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
-    stack_num = workspace_num % 10
-    stack = (w for w in ipc.get_workspaces() 
-             if w.num % 10 == stack_num and w.num > 10)
-    sorted_stack = sorted(stack, key=lambda w: w.num)
-
-    if not workspace.leaves():
-        bottom_num = sorted_stack[0].num
-        ipc.command(f"workspace {bottom_num}")
-        # if empty, pop down from the stack
-        for ws in sorted_stack:
-            num = ws.num
-            ipc.command(f"rename workspace {num} to {num-10}")
-    # else, do nothing
-
-
-def rotate_down(workspace):
-    workspace_num = workspace.num
-
-    # only call from "home row"
-    if not (workspace_num >= 1 and workspace_num <= 10):
-        return
-
-    stack_num = workspace_num % 10
-
-    # TODO: cleanup repeat code
-    if workspace.leaves():
-        # if workspace not empty, place on opposite end of stack
-        stack = (w for w in ipc.get_workspaces() 
-                 if w.num % 10 == stack_num and w.num != 0)
-        top_stack = max(stack, key=lambda w: w.num)
-        top_num = top_stack.num
-
         ipc.command(f"rename workspace {workspace_num} to {top_num+10}")
-
-    stack = (w for w in ipc.get_workspaces() 
-             if w.num % 10 == stack_num and w.num > 10)
-    sorted_stack = sorted(stack, key=lambda w: w.num)
-
-    bottom_num = sorted_stack[0].num
-    ipc.command(f"workspace {bottom_num}")
-    for ws in sorted_stack:
-        num = ws.num
-        ipc.command(f"rename workspace {num} to {num-10}")
+        ipc.command(f"workspace {workspace_num}")
 
 
-def rotate_up(workspace):
+def workspace_pop(workspace):
     workspace_num = workspace.num
 
     # only call from "home row"
     if not (workspace_num >= 1 and workspace_num <= 10):
         return
 
-    stack_num = workspace_num % 10
+    top_num = get_stack_top(workspace_num)
 
-    # TODO: cleanup repeat code
+    # if empty, pop from stack
+    if not workspace.leaves():
+        ipc.command(f"workspace {top_num}")
+        ipc.command(f"rename workspace {top_num} to {workspace_num}")
+
+
+def workspace_pop_rotate(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    top_num = get_stack_top(workspace_num)
+
+    # if workspace not empty, rotate stack before pop
     if workspace.leaves():
-        stack = (w for w in ipc.get_workspaces() 
-                 if w.num % 10 == stack_num and w.num != 0)
-        sorted_stack = sorted(stack, key=lambda w: w.num, reverse=True)
+        for n in range(top_num, 0, -10):
+            ipc.command(f"rename workspace {n} to {n+10}")
 
-        for ws in sorted_stack:
-            num = ws.num
-            ipc.command(f"rename workspace {num} to {num+10}")
+        top_num += 10
 
-    stack = (w for w in ipc.get_workspaces() 
-             if w.num % 10 == stack_num and w.num > 10)
-    top_stack = max(stack, key=lambda w: w.num)
-    top_num = top_stack.num
-
+    # pop
     ipc.command(f"workspace {top_num}")
     ipc.command(f"rename workspace {top_num} to {workspace_num}")
+
+
+def workspace_push_rotate(workspace):
+    workspace_num = workspace.num
+
+    # only call from "home row"
+    if not (workspace_num >= 1 and workspace_num <= 10):
+        return
+
+    top_num = get_stack_top(workspace_num)
+
+    # if workspace not empty, push before rotate
+    if workspace.leaves():
+        ipc.command(f"rename workspace {workspace_num} to {top_num+10}")
+        top_num += 10
+
+    # rotate
+    ipc.command(f"workspace {workspace_num+10}")
+    for n in range(workspace_num+10, top_num+10, 10):
+        ipc.command(f"rename workspace {n} to {n-10}")
 
 
 if __name__ == "__main__":
@@ -131,22 +108,22 @@ if __name__ == "__main__":
     )
     action = parser.add_mutually_exclusive_group()
     action.add_argument(
-        "--up",
+        "--push", "--up",
         action="store_true",
         help="Push non-empty focused workspace onto stack (default)",
     )
     action.add_argument(
-        "--down",
+        "--pop", "--down",
         action="store_true",
         help="Pop top of stack onto empty focused workspace",
     )
     action.add_argument(
-        "--rot-down",
+        "--pop-rotate", "--rot-down",
         action="store_true",
         help="Rotate down along the focused workspace stack",
     )
     action.add_argument(
-        "--rot-up",
+        "--push-rotate", "--rot-up",
         action="store_true",
         help="Rotate up along the focused workspace stack",
     )
@@ -155,11 +132,11 @@ if __name__ == "__main__":
     ipc = i3ipc.Connection()
     focused = ipc.get_tree().find_focused().workspace()
 
-    if args.down:
-        shift_down(focused)
-    elif args.rot_down:
-        rotate_down(focused)
-    elif args.rot_up:
-        rotate_up(focused)
+    if args.pop:
+        workspace_pop(focused)
+    elif args.pop_rotate:
+        workspace_pop_rotate(focused)
+    elif args.push_rotate:
+        workspace_push_rotate(focused)
     else:
-        shift_up(focused)
+        workspace_push(focused)


### PR DESCRIPTION
This is a refactor of the swaystack script that improves the stack analogy to be more consistent, as well as to reduce the shuffling of workspaces and overall to clean up some messy parts of the code.

The behavior from the user's perspective is exactly the same. The names of the arguments are changed to be consistent with the stack analogy, but the old argument are maintained for backwards compatability.