### PR TITLE
swaystack: Improve multi-monitor support

### DIFF
--- a/swaystack.py
+++ b/swaystack.py
@@ -24,6 +24,17 @@ import argparse
 import i3ipc
 
 
+def get_output(con):
+    ret = con
+
+    while ret:
+        if ret.type == "output":
+            break
+        ret = ret.parent
+
+    return ret
+
+
 def get_stack_top(stack_num):
     num = stack_num % 10
     return max(w.num for w in ipc.get_workspaces()
@@ -43,16 +54,19 @@ def workspace_push(workspace):
 def workspace_pop(workspace):
     workspace_num = workspace.num
     top_num = get_stack_top(workspace_num)
+    output = get_output(workspace)
 
     # if empty, pop from stack
     if not workspace.leaves():
         ipc.command(f"workspace {top_num}")
+        ipc.command(f"move workspace to output {output.name}")
         ipc.command(f"rename workspace {top_num} to {workspace_num}")
 
 
 def workspace_pop_rotate(workspace):
     workspace_num = workspace.num
     top_num = get_stack_top(workspace_num)
+    output = get_output(workspace)
 
     # if workspace not empty, rotate stack before pop
     if workspace.leaves():
@@ -63,12 +77,14 @@ def workspace_pop_rotate(workspace):
 
     # pop
     ipc.command(f"workspace {top_num}")
+    ipc.command(f"move workspace to output {output.name}")
     ipc.command(f"rename workspace {top_num} to {workspace_num}")
 
 
 def workspace_push_rotate(workspace):
     workspace_num = workspace.num
     top_num = get_stack_top(workspace_num)
+    output = get_output(workspace)
 
     # if workspace not empty, push before rotate
     if workspace.leaves():
@@ -77,6 +93,7 @@ def workspace_push_rotate(workspace):
 
     # rotate
     ipc.command(f"workspace {workspace_num+10}")
+    ipc.command(f"move workspace to output {output.name}")
     for n in range(workspace_num+10, top_num+1, 10):
         ipc.command(f"rename workspace {n} to {n-10}")
 


### PR DESCRIPTION
I never thought to test swaystack with multiple monitors before, and things get a little messy when I plugged into another monitor.

Swaystack pops by checking the current workspace is empty, focusing the workspace in the stack to free up the workspace name, and renaming to the workspace on the home row. If the stack happens to be on another monitor, then the empty home row workspace won't get cleaned up and renaming to it will fail. This is solved in this PR by, after focusing the workspace to be popped, moving it to the active monitor such that the old empty workspace will no longer be focused on the unfocused monitor and get cleaned up.

This change makes the script usable with multiple monitors but it's still not ideal for a few reasons:

1. Previously you could see how many workspaces are in each stack by looking at your workspace list. If the stack is split across multiple monitors, this gets messy. This could be solved by making sure all workspaces in the stack are on the same monitor, but I'm not sure it's worth the complexity. It might also add "flickering", where the focused workspace quickly switches more than once, which I try to avoid.
2. Since all monitors need a focused workspace, there are certain cases where sway will automatically focus the last focused workspace (such as when moving workspaces between monitors). This, along with a couple other cases, can lead to workspaces in the stack being focused. Ideally this should never happen, but it's relatively minor since you can just focus back onto the home row manually. I don't think there's any good solution to this.
3. There is still flickering on the un-focused monitor if the stack workspace to be popped is not on the focused output. I don't think there's a way to resolve this since I don't think there's a way to move unfocused workspaces between outputs.

This PR can be merged as-is. I might get around to making more changes to make it cleaner, but I don't like any solutions I've come up with so far.